### PR TITLE
Fix BorderAdmin class

### DIFF
--- a/geodjango/import.md
+++ b/geodjango/import.md
@@ -584,7 +584,7 @@ from leaflet.admin import LeafletGeoAdmin
 
 class BorderAdmin(LeafletGeoAdmin):
   search_fields = ['n03_001','n03_003','n03_004']
-  list_filter = ('n03_003')
+  list_filter = ('n03_003',)
 
 admin.site.register(Border, BorderAdmin)
 admin.site.register(School, LeafletGeoAdmin)


### PR DESCRIPTION
Fixed error on line 587 of geodjango/import.md

```
ERRORS:
<class 'world.admin.BorderAdmin'>: (admin.E112) The value of 'list_filter' must be a list or tuple.
```
